### PR TITLE
Potential fix for code scanning alert no. 1: Exposure of private files

### DIFF
--- a/AI-900/AI-900-bonus/01-SIMULADO/js/servidor.js
+++ b/AI-900/AI-900-bonus/01-SIMULADO/js/servidor.js
@@ -8,7 +8,8 @@ const PORT = 3000;
 const arquivoQuestoes = path.join(__dirname, 'questoes.js');
 const arquivoCorrigir = path.join(__dirname, 'corrigir-dominios.js');
 
-app.use(express.static(__dirname)); // para servir o index.html
+app.use('/index.html', express.static(path.join(__dirname, 'index.html'))); // Serves index.html
+app.use('/public', express.static(path.join(__dirname, 'public'))); // Serves public subdirectory
 
 app.get('/questoes', (req, res) => {
   fs.readFile(arquivoQuestoes, 'utf8', (err, data) => {


### PR DESCRIPTION
Potential fix for [https://github.com/raphaelbarretopro/certiacademy/security/code-scanning/1](https://github.com/raphaelbarretopro/certiacademy/security/code-scanning/1)

To fix this issue, restrict the static file serving to only the specific files or subdirectories that are meant to be publicly accessible. This can be achieved by explicitly specifying paths to the files or subdirectories that need to be served. For example, if the `AI-900/AI-900-bonus/01-SIMULADO/js` directory contains only `index.html` and a `public` subdirectory for client-side assets, the code can be updated to serve only these specific resources.

This involves replacing the problematic `app.use(express.static(__dirname))` with explicit routes for the files or subdirectories that should be served.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
