### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/AI-900/AI-900-bonus/02-SIMULADO/js/package.json
+++ b/AI-900/AI-900-bonus/02-SIMULADO/js/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "express-rate-limit": "^8.0.1"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/raphaelbarretopro/certiacademy/security/code-scanning/6](https://github.com/raphaelbarretopro/certiacademy/security/code-scanning/6)

To fix this issue, a rate-limiting middleware should be applied to the application or specifically to the `/corrigir` route. The `express-rate-limit` package is a well-known and widely used middleware for this purpose. It allows us to limit the number of requests a client can make to a particular route within a specified time window.

Steps to implement the fix:
1. Install the `express-rate-limit` package.
2. Create a rate limiter with appropriate configurations (e.g., maximum requests allowed within a time window).
3. Apply the rate limiter to the `/corrigir` route using `app.post`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
